### PR TITLE
Fixes for the duplicate method

### DIFF
--- a/hvac/fluid_flow/conduit/conduit.py
+++ b/hvac/fluid_flow/conduit/conduit.py
@@ -227,8 +227,8 @@ class Conduit(AbstractConduit):
             obj._pressure_drop = specific_pressure_drop * obj.length
         obj._fittings = kwargs.get('fittings', deepcopy(conduit._fittings))
         obj.ID = kwargs.get('ID', deepcopy(conduit.ID))
-        obj.start_node = kwargs.get('start_node', deepcopy(conduit.start_node))
-        obj.end_node = kwargs.get('end_node', deepcopy(conduit.end_node))
+        obj.start_node = kwargs.get("start_node", conduit.start_node)
+        obj.end_node = kwargs.get("end_node", conduit.end_node)
         obj.flow_sign = kwargs.get('flow_sign', deepcopy(conduit.flow_sign))
         obj.loops = kwargs.get('loops', deepcopy(conduit.loops))
         obj.machine_coefficients = kwargs.get('machine_coefficients', obj.machine_coefficients)

--- a/hvac/fluid_flow/network/network.py
+++ b/hvac/fluid_flow/network/network.py
@@ -184,11 +184,13 @@ class Network(ABC):
                 loop = self.loops.setdefault(loop_ID[0], Loop(loop_ID[0]))
                 other_loop = self.loops.setdefault(loop_ID[1], Loop(loop_ID[1]))
 
-                loop.append(conduit)
-                conduit.loops = [self.loops[loop_ID[0]], self.loops[loop_ID[1]]]
-
+                conduit.loops = []
                 conduit_duplicate = Conduit.duplicate(conduit, flow_sign=conduit.flow_sign.reverse())
+
+                loop.append(conduit)
                 other_loop.append(conduit_duplicate)
+
+                conduit.loops = [self.loops[loop_ID[0]], self.loops[loop_ID[1]]]
                 conduit_duplicate.loops = [self.loops[loop_ID[1]], self.loops[loop_ID[0]]]
 
             if isinstance(loop_ID, str) and len(loop_ID) > 0:


### PR DESCRIPTION
More fixes for the duplicate method on Conduit - the deepcopy also navigates into Loops Nodes and eventually stumbles into CoolProps. I'm not sure it's really the right thing to recreate the start and end nodes anyway.

In the case of _create_loops I just had to reorder the statements such that when the copy happens, there are no loops on the conduit... but the net effect should be the same